### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -1,4 +1,6 @@
 name: Makefile CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/mikhail-kirillov/s21_cat/security/code-scanning/1](https://github.com/mikhail-kirillov/s21_cat/security/code-scanning/1)

To fix the issue, add a `permissions` block at the root level of the workflow file to explicitly limit the permissions of the `GITHUB_TOKEN`. Since the workflow only performs basic CI tasks like building and testing code, it likely only requires `contents: read` permissions. This change ensures the workflow adheres to the principle of least privilege and avoids granting unnecessary write access.

The `permissions` block should be added directly below the `name` field at the top of the file. No additional imports, methods, or definitions are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
